### PR TITLE
Fixed Android Call Receive when on BG for API Level < 29

### DIFF
--- a/android/src/main/java/space/amal/twilio/RNTwilioVoiceLibraryModule.java
+++ b/android/src/main/java/space/amal/twilio/RNTwilioVoiceLibraryModule.java
@@ -202,6 +202,10 @@ public class RNTwilioVoiceLibraryModule extends ReactContextBaseJavaModule imple
         if (BuildConfig.DEBUG) {
             Log.d(TAG, "onNewIntent " + intent.toString());
         }
+        if (android.os.Build.VERSION.SDK_INT < 29) {
+            Log.w("RNTwilioVoiceAmal", "Ignored Duplicate Call to HandleIncoming");
+            return;
+        }
         handleIncomingCallIntent(intent);
     }
 


### PR DESCRIPTION
On API Level < 29 , this gets called second time automatically as a duplicate call and the actual call gets disconnected. Does not happen on API 29. Hence the caller was dropping call when the APP was on BG.